### PR TITLE
Update htmlv2.pug - Fixed Top and Bottom Controllers not Activating

### DIFF
--- a/templates/htmlv2.pug
+++ b/templates/htmlv2.pug
@@ -233,7 +233,7 @@ script.
 
 	window.addEventListener("click", (event) => {
 
-		if(!event.path.find((el) => el.id === "top-control" || el.id === "bottom-control")){
+		if(!event.composedPath().some((el) => el.id === "top-control" || el.id === "bottom-control")){
 			document.querySelector("#top-control").classList.toggle("active");
 			document.querySelector("#bottom-control").classList.toggle("active");
 		}


### PR DESCRIPTION
Update htmlv2.pug
Updated how top and bottom controllers activate and deactivate in html.

Use event.composedPath() instead of event.path.find(), which didn't work.