### PR TITLE
Update htmlv2.pug | Add Per-Story ScrollSave Support.

### DIFF
--- a/templates/htmlv2.pug
+++ b/templates/htmlv2.pug
@@ -162,6 +162,7 @@ html(lang=langName)
 		meta(charset="UTF-8")
 		title= book.title
 		meta(name="viewport" content="width=device-width, initial-scale=1.0")
+		meta(name="scroll-key" content= book.id)
 
 	body
 
@@ -209,7 +210,13 @@ html(lang=langName)
 
 script.
 	const fontList = ["Arial, sans-serif", "Verdana, sans-serif", "Cambria, serif", "cursive", "monospace"];
-	let scrollsave = localStorage.getItem("scrollsave");
+	const scrollKey = document.querySelector('meta[name="scroll-key"]')?.content;
+	let scrollsave;
+	if (scrollKey) {
+		scrollsave = localStorage.getItem(`scrollsave_${scrollKey}`);
+	} else {
+		console.warn("No scroll key defined in the HTML.");
+	}	
 	let fontsize = localStorage.getItem("fontsize");
 	let colormode = localStorage.getItem("colormode");
 	let font = localStorage.getItem("font");
@@ -255,7 +262,7 @@ script.
 		window.clearTimeout(isScrolling);
 
 		isScrolling = setTimeout(() => {
-			localStorage.setItem("scrollsave", currentScroll.toString());
+			localStorage.setItem(`scrollsave_${scrollKey}`, currentScroll.toString());
 		}, 80);
 
 	});


### PR DESCRIPTION
Update htmlv2.pug
Add per-story scrollsave support.

Browsers treat file:// (desktop) and content:// (android) urls as from the same origin regadless the directory they're in. So if we have multiple stories downloaded, the scrollsave value is shared among them.

By adding book id to the localStorage key, we can ensure that scrollsave is specific to each story.